### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 description = "Bussin protocol sanity checker"
 license-file= "LICENSE"
-homepage = "https://github.com/OmentaElvis/buss-sc"
+repository = "https://github.com/OmentaElvis/buss-sc"
 
 [dependencies]
 clap = { version = "4.5.4", features = ["string"] }


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.